### PR TITLE
Warn user when modifying workflow state of parent pages that it will affect children

### DIFF
--- a/ecc_parents.libraries.yml
+++ b/ecc_parents.libraries.yml
@@ -3,3 +3,10 @@ views:
   css:
     theme:
       css/views.css: {}
+
+node.form:
+  js:
+    js/node_form.js: {}
+  dependencies:
+    - core/jquery
+    - core/once

--- a/ecc_parents.libraries.yml
+++ b/ecc_parents.libraries.yml
@@ -5,6 +5,7 @@ views:
       css/views.css: {}
 
 node.form:
+  version: 1.0.0
   js:
     js/node_form.js: {}
   dependencies:

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -88,6 +88,15 @@ function ecc_parents_form_node_form_alter(&$form, FormStateInterface $form_state
   if (isset($form['field_publish_with_parent']) && isset($form['advanced'])) {
     $form['field_publish_with_parent']['#group'] = 'footer';
   }
+  $nid = $form_state->getformObject()->getEntity()->id();
+  if (isset($nid) && !empty($nid)) {
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+    $parents_service = \Drupal::service('ecc_parents.parents');
+    $children = $parents_service->getChildren($node);
+    if (!empty($children)) {
+      $form['#attached']['library'][] = 'ecc_parents/node.form';
+    }
+  }
 }
 
 /**

--- a/js/node_form.js
+++ b/js/node_form.js
@@ -1,0 +1,15 @@
+(function ($, Drupal) {
+  Drupal.behaviors.eccParentsNodeForm = {
+    attach: function (context, settings) {
+      $(once("ecc-parents", "#edit-submit", context)).on('click', (e) => {
+        let state = $("#edit-moderation-state-0-state").val();
+        if (state !== 'published') {
+          if (false == confirm(Drupal.t("If you save the node as this, its children may end up unpublished. " +
+            "Do you want to continue?"))) {
+            e.preventDefault();
+          };
+        }
+      });
+    }
+};
+})(jQuery, Drupal);


### PR DESCRIPTION
adds a javascript confirmation box which is attached to the save button on a node edit form for parent nodes with children.
https://eccservicetransformation.atlassian.net/browse/LP-335