### PR TITLE
Update child guide pages with contacts from guide overview page on save

### DIFF
--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -51,41 +51,56 @@ function ecc_parents_node_presave(EntityInterface $entity) {
 
   // Update pages based on changes to overview.
   if ($entity->bundle() === 'localgov_guides_overview') {
-    $new_service_contacts = $entity->get('localgov_service_contacts')
-      ?->referencedEntities();
-    $old_service_contacts = $entity->original->get('localgov_service_contacts')
-      ?->referencedEntities();
-    if ($old_service_contacts === $new_service_contacts) {
-      // Service contacts are unchanged: nothing to update.
+    // Cascade is default behaviour unless editors turn it off.
+    $cascade_contacts = TRUE;
+    // Check for a switch for editor choice.
+    // If the field isn't there, default behaviour kicks in.
+    if ($entity->hasField('field_guide_cascade_contacts')) {
+
+      if (!empty($entity->get('field_guide_cascade_contacts')->value)) {
+        $cascade_contacts = TRUE;
+      }
+      else {
+         $cascade_contacts = FALSE;
+      }
     }
-    else {
-      // Get all children.
-      $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
-      if (!empty($child_pages)) {
-        // Iterate over children.
-        foreach ($child_pages as $child_page) {
-          // For each child, get service contacts.
-          $child_contacts = $child_page->get('localgov_service_contacts')
+    if ($cascade_contacts) {
+      $new_service_contacts = $entity->get('localgov_service_contacts')
       ?->referencedEntities();
-          // For each old contact, remove from child contacts.
-          if (!empty($child_contacts)) {
-            foreach ($old_service_contacts as $i => $old_contact) {
-              foreach ($child_contacts as $child_contact) {
-                if ($child_contact->id() === $old_contact->id()) {
-                  // Remove the old contact from the child node.
-                  unset($child_contacts[$i]);
+      $old_service_contacts = $entity->original->get('localgov_service_contacts')
+        ?->referencedEntities();
+      if ($old_service_contacts === $new_service_contacts) {
+        // Service contacts are unchanged: nothing to update.
+      }
+      else {
+        // Get all children.
+        $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
+        if (!empty($child_pages)) {
+          // Iterate over children.
+          foreach ($child_pages as $child_page) {
+            // For each child, get service contacts.
+            $child_contacts = $child_page->get('localgov_service_contacts')
+        ?->referencedEntities();
+            // For each old contact, remove from child contacts.
+            if (!empty($child_contacts)) {
+              foreach ($old_service_contacts as $i => $old_contact) {
+                foreach ($child_contacts as $child_contact) {
+                  if ($child_contact->id() === $old_contact->id()) {
+                    // Remove the old contact from the child node.
+                    unset($child_contacts[$i]);
+                  }
                 }
               }
             }
+            else {
+              $child_contacts = [];
+            }
+            // Add new contacts.
+            $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
+            // Save.
+            $child_page->set('localgov_service_contacts', $new_child_contacts);
+            $child_page->save();
           }
-          else {
-            $child_contacts = [];
-          }
-          // Add new contacts.
-          $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
-          // Save.
-          $child_page->set('localgov_service_contacts', $new_child_contacts);
-          $child_page->save();
         }
       }
     }

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -101,20 +101,10 @@ function ecc_parents_node_presave(EntityInterface $entity) {
             }
             // Add new contacts.
             $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
-
-            $unique_contacts = [];
-            $seen_ids = [];
-            foreach ($new_child_contacts as $new_child_contact) {
-              $id = $new_child_contact['target_id'];
-              if (!in_array($id, $seen_ids)) {
-                $seen_ids[] = $id;
-                $unique_contacts[] = $new_child_contact;
-              }
-            }
-            $new_child_contacts = $unique_contacts;
+            $unique_contacts = array_unique($new_child_contacts, SORT_REGULAR);
 
             // Save.
-            $child_page->set('localgov_service_contacts', $new_child_contacts);
+            $child_page->set('localgov_service_contacts', $unique_contacts);
             $child_page->save();
           }
         }

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -71,50 +71,51 @@ function ecc_parents_node_presave(EntityInterface $entity) {
         ?->getValue();
       if ($old_service_contacts === $new_service_contacts) {
         // Service contacts are unchanged: nothing to update.
+        return;
       }
-      else {
-        // We'll need to bail if there's no child pages field.
-        if ($entity->hasField('localgov_guides_pages')) {
-          // Get all children.
-          $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
-          if (!empty($child_pages)) {
-            // Iterate over children.
-            foreach ($child_pages as $child_page) {
-              // For each child, get service contacts.
-              $child_contacts = $child_page->get('localgov_service_contacts')
-          ?->getValue();
-              // For each old contact, remove from child contacts.
-              if (!empty($child_contacts)) {
-                foreach ($old_service_contacts as $i => $old_contact) {
-                  foreach ($child_contacts as $child_contact) {
-                    if ($child_contact['target_id'] === $old_contact['target_id']) {
-                      // Remove the old contact from the child node.
-                      unset($child_contacts[$i]);
-                    }
+
+      // Assuming we haven't bailed, we can proceed to update child pages.
+      // We'll need to bail if there's no child pages field.
+      if ($entity->hasField('localgov_guides_pages')) {
+        // Get all children.
+        $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
+        if (!empty($child_pages)) {
+          // Iterate over children.
+          foreach ($child_pages as $child_page) {
+            // For each child, get service contacts.
+            $child_contacts = $child_page->get('localgov_service_contacts')
+        ?->getValue();
+            // For each old contact, remove from child contacts.
+            if (!empty($child_contacts)) {
+              foreach ($old_service_contacts as $i => $old_contact) {
+                foreach ($child_contacts as $j => $child_contact) {
+                  if ($child_contact['target_id'] === $old_contact['target_id']) {
+                    // Remove the old contact from the child node.
+                    unset($child_contacts[$j]);
                   }
                 }
               }
-              else {
-                $child_contacts = [];
-              }
-              // Add new contacts.
-              $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
-
-              $unique_contacts = [];
-              $seen_ids = [];
-              foreach ($new_child_contacts as $new_child_contact) {
-                $id = $new_child_contact['target_id'];
-                if (!in_array($id, $seen_ids)) {
-                  $seen_ids[] = $id;
-                  $unique_contacts[] = $new_child_contact;
-                }
-              }
-              $new_child_contacts = $unique_contacts;
-
-              // Save.
-              $child_page->set('localgov_service_contacts', $new_child_contacts);
-              $child_page->save();
             }
+            else {
+              $child_contacts = [];
+            }
+            // Add new contacts.
+            $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
+
+            $unique_contacts = [];
+            $seen_ids = [];
+            foreach ($new_child_contacts as $new_child_contact) {
+              $id = $new_child_contact['target_id'];
+              if (!in_array($id, $seen_ids)) {
+                $seen_ids[] = $id;
+                $unique_contacts[] = $new_child_contact;
+              }
+            }
+            $new_child_contacts = $unique_contacts;
+
+            // Save.
+            $child_page->set('localgov_service_contacts', $new_child_contacts);
+            $child_page->save();
           }
         }
       }

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -97,6 +97,18 @@ function ecc_parents_node_presave(EntityInterface $entity) {
             }
             // Add new contacts.
             $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
+            // De-duplicate the contacts for the child node.
+            $unique_contacts = [];
+            $seen_ids = [];
+            foreach ($new_child_contacts as $new_child_contact) {
+              $id = $new_child_contact->id();
+              if (!in_array($id, $seen_ids)) {
+                $seen_ids[] = $id;
+                $unique_contacts[] = $new_child_contact;
+              }
+            }
+            $new_child_contacts = $unique_contacts;
+
             // Save.
             $child_page->set('localgov_service_contacts', $new_child_contacts);
             $child_page->save();

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -13,8 +13,21 @@ use Drupal\views\ViewExecutable;
  * Implements hook_ENTITY_TYPE_presave().
  *
  * Set service contacts from parent page if not already set.
+ *
+ * Also set service contacts on guide pages if overview page updated.
+ *
+ * Scenarios:
+ * Guide overview old values: paul, mary
+ * changed to
+ * new values: john, pat
+ *
+ * Match old: paul, mary -> john,pat (replace)
+ * Match new: john, pat -> john, pat (replace/no change)
+ * Partial match: paul, sile -> john, sile, pat (remove & copy)
+ * No match: frances -> frances, john, pat (copy)
  */
 function ecc_parents_node_presave(EntityInterface $entity) {
+  // Set guide page contacts based upon parent.
   /** @var \Drupal\node\NodeInterface $entity */
 
   // Add other content types, when required.
@@ -23,7 +36,6 @@ function ecc_parents_node_presave(EntityInterface $entity) {
   if (in_array($entity->bundle(), $content_types)) {
     /** @var \Drupal\ecc_parents\Parents $parents_service */
     $parents_service = \Drupal::service('ecc_parents.parents');
-
     $service_contact = $entity->get('localgov_service_contacts')
       ?->referencedEntities();
     if (empty($service_contact)) {
@@ -32,6 +44,48 @@ function ecc_parents_node_presave(EntityInterface $entity) {
           ->getValue();
         if ($parent_service_contacts) {
           $entity->set('localgov_service_contacts', $parent_service_contacts);
+        }
+      }
+    }
+  }
+
+  // Update pages based on changes to overview.
+  if ($entity->bundle() === 'localgov_guides_overview') {
+    $new_service_contacts = $entity->get('localgov_service_contacts')
+      ?->referencedEntities();
+    $old_service_contacts = $entity->original->get('localgov_service_contacts')
+      ?->referencedEntities();
+    if ($old_service_contacts === $new_service_contacts) {
+      // Service contacts are unchanged: nothing to update.
+    }
+    else {
+      // Get all children.
+      $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
+      if (!empty($child_pages)) {
+        // Iterate over children.
+        foreach ($child_pages as $child_page) {
+          // For each child, get service contacts.
+          $child_contacts = $child_page->get('localgov_service_contacts')
+      ?->referencedEntities();
+          // For each old contact, remove from child contacts.
+          if (!empty($child_contacts)) {
+            foreach ($old_service_contacts as $i => $old_contact) {
+              foreach ($child_contacts as $child_contact) {
+                if ($child_contact->id() === $old_contact->id()) {
+                  // Remove the old contact from the child node.
+                  unset($child_contacts[$i]);
+                }
+              }
+            }
+          }
+          else {
+            $child_contacts = [];
+          }
+          // Add new contacts.
+          $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
+          // Save.
+          $child_page->set('localgov_service_contacts', $new_child_contacts);
+          $child_page->save();
         }
       }
     }

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -73,45 +73,48 @@ function ecc_parents_node_presave(EntityInterface $entity) {
         // Service contacts are unchanged: nothing to update.
       }
       else {
-        // Get all children.
-        $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
-        if (!empty($child_pages)) {
-          // Iterate over children.
-          foreach ($child_pages as $child_page) {
-            // For each child, get service contacts.
-            $child_contacts = $child_page->get('localgov_service_contacts')
-        ?->referencedEntities();
-            // For each old contact, remove from child contacts.
-            if (!empty($child_contacts)) {
-              foreach ($old_service_contacts as $i => $old_contact) {
-                foreach ($child_contacts as $child_contact) {
-                  if ($child_contact->id() === $old_contact->id()) {
-                    // Remove the old contact from the child node.
-                    unset($child_contacts[$i]);
+        // We'll need to bail if there's no child pages field.
+        if ($entity->hasField('localgov_guides_pages')) {
+          // Get all children.
+          $child_pages = $entity->get('localgov_guides_pages')?->referencedEntities();
+          if (!empty($child_pages)) {
+            // Iterate over children.
+            foreach ($child_pages as $child_page) {
+              // For each child, get service contacts.
+              $child_contacts = $child_page->get('localgov_service_contacts')
+          ?->referencedEntities();
+              // For each old contact, remove from child contacts.
+              if (!empty($child_contacts)) {
+                foreach ($old_service_contacts as $i => $old_contact) {
+                  foreach ($child_contacts as $child_contact) {
+                    if ($child_contact->id() === $old_contact->id()) {
+                      // Remove the old contact from the child node.
+                      unset($child_contacts[$i]);
+                    }
                   }
                 }
               }
-            }
-            else {
-              $child_contacts = [];
-            }
-            // Add new contacts.
-            $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
-            // De-duplicate the contacts for the child node.
-            $unique_contacts = [];
-            $seen_ids = [];
-            foreach ($new_child_contacts as $new_child_contact) {
-              $id = $new_child_contact->id();
-              if (!in_array($id, $seen_ids)) {
-                $seen_ids[] = $id;
-                $unique_contacts[] = $new_child_contact;
+              else {
+                $child_contacts = [];
               }
-            }
-            $new_child_contacts = $unique_contacts;
+              // Add new contacts.
+              $new_child_contacts = array_merge($child_contacts, $new_service_contacts);
 
-            // Save.
-            $child_page->set('localgov_service_contacts', $new_child_contacts);
-            $child_page->save();
+              $unique_contacts = [];
+              $seen_ids = [];
+              foreach ($new_child_contacts as $new_child_contact) {
+                $id = $new_child_contact->id();
+                if (!in_array($id, $seen_ids)) {
+                  $seen_ids[] = $id;
+                  $unique_contacts[] = $new_child_contact;
+                }
+              }
+              $new_child_contacts = $unique_contacts;
+
+              // Save.
+              $child_page->set('localgov_service_contacts', $new_child_contacts);
+              $child_page->save();
+            }
           }
         }
       }

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -64,9 +64,9 @@ function ecc_parents_node_presave(EntityInterface $entity) {
          $cascade_contacts = FALSE;
       }
     }
-    if ($cascade_contacts) {
+    if ($cascade_contacts && $entity->hasField('localgov_service_contacts')) {
       $new_service_contacts = $entity->get('localgov_service_contacts')
-      ?->getValue();
+        ?->getValue();
       $old_service_contacts = $entity->original->get('localgov_service_contacts')
         ?->getValue();
       if ($old_service_contacts === $new_service_contacts) {
@@ -82,9 +82,12 @@ function ecc_parents_node_presave(EntityInterface $entity) {
         if (!empty($child_pages)) {
           // Iterate over children.
           foreach ($child_pages as $child_page) {
+            if (!$child_page->hasField('localgov_service_contacts')) {
+              continue;
+            }
             // For each child, get service contacts.
             $child_contacts = $child_page->get('localgov_service_contacts')
-        ?->getValue();
+              ?->getValue();
             // For each old contact, remove from child contacts.
             if (!empty($child_contacts)) {
               foreach ($old_service_contacts as $i => $old_contact) {

--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -66,9 +66,9 @@ function ecc_parents_node_presave(EntityInterface $entity) {
     }
     if ($cascade_contacts) {
       $new_service_contacts = $entity->get('localgov_service_contacts')
-      ?->referencedEntities();
+      ?->getValue();
       $old_service_contacts = $entity->original->get('localgov_service_contacts')
-        ?->referencedEntities();
+        ?->getValue();
       if ($old_service_contacts === $new_service_contacts) {
         // Service contacts are unchanged: nothing to update.
       }
@@ -82,12 +82,12 @@ function ecc_parents_node_presave(EntityInterface $entity) {
             foreach ($child_pages as $child_page) {
               // For each child, get service contacts.
               $child_contacts = $child_page->get('localgov_service_contacts')
-          ?->referencedEntities();
+          ?->getValue();
               // For each old contact, remove from child contacts.
               if (!empty($child_contacts)) {
                 foreach ($old_service_contacts as $i => $old_contact) {
                   foreach ($child_contacts as $child_contact) {
-                    if ($child_contact->id() === $old_contact->id()) {
+                    if ($child_contact['target_id'] === $old_contact['target_id']) {
                       // Remove the old contact from the child node.
                       unset($child_contacts[$i]);
                     }
@@ -103,7 +103,7 @@ function ecc_parents_node_presave(EntityInterface $entity) {
               $unique_contacts = [];
               $seen_ids = [];
               foreach ($new_child_contacts as $new_child_contact) {
-                $id = $new_child_contact->id();
+                $id = $new_child_contact['target_id'];
                 if (!in_array($id, $seen_ids)) {
                   $seen_ids[] = $id;
                   $unique_contacts[] = $new_child_contact;


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-222

- update service contacts on child guide pages
- happens in hook_node_presave()
- extends existing implementation
- checks for editor controls, but takes default action if they aren't there.