### PR TITLE
Account for new nodes when checking for original contact values.

### DIFF
--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -67,11 +67,17 @@ function ecc_parents_node_presave(EntityInterface $entity) {
     if ($cascade_contacts && $entity->hasField('localgov_service_contacts')) {
       $new_service_contacts = $entity->get('localgov_service_contacts')
         ?->getValue();
-      $old_service_contacts = $entity->original->get('localgov_service_contacts')
+      // New nodes won't have existing contacts, so we can set an empty array.
+      if (!$entity->isNew()) {
+        $old_service_contacts = $entity->original->get('localgov_service_contacts')
         ?->getValue();
-      if ($old_service_contacts === $new_service_contacts) {
-        // Service contacts are unchanged: nothing to update.
-        return;
+        if ($old_service_contacts === $new_service_contacts) {
+          // Service contacts are unchanged: nothing to update.
+          return;
+        }
+      }
+      else {
+        $old_service_contacts = [];
       }
 
       // Assuming we haven't bailed, we can proceed to update child pages.


### PR DESCRIPTION
in hook_node_presave() we were assuming old contacts, but new nodes have no 'original' value, so it fails for new nodes 
https://eccservicetransformation.atlassian.net/browse/LP-222

Checks: 'is this a new node?'
and then either 
- gets contacts from original and checks for changes and possibly bails
- or creates an empty array for old contacts if it's new