### PR TITLE
Remove all publish-with-parent functionality 

### DIFF
--- a/ecc_parents.module
+++ b/ecc_parents.module
@@ -123,67 +123,6 @@ function ecc_parents_node_presave(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_update().
- *
- * When a page is published/unpublished then do the same for its children.
- *
- * Beware of loops! It doesn't look like it's a problem but saving a guide page
- * could try to save the overview again.
- *
- * @see \Drupal\localgov_guides\ChildParentRelationship
- */
-function ecc_parents_node_update(EntityInterface $entity) {
-  /** @var \Drupal\node\NodeInterface $entity */
-
-  // Add other content types, when required.
-  $content_types = ['localgov_guides_overview'];
-
-  if (in_array($entity->bundle(), $content_types)) {
-    /** @var \Drupal\ecc_parents\Parents $parents_service */
-    $parents_service = \Drupal::service('ecc_parents.parents');
-
-    if (!$entity->original->isPublished() && $entity->isPublished()) {
-      foreach ($parents_service->getChildren($entity) as $child) {
-        if (!$child->isPublished() && $child->field_publish_with_parent->value) {
-          $child->setPublished();
-          $child->set('moderation_state', 'published');
-          $child->save();
-        }
-      }
-    }
-    elseif ($entity->original->isPublished() && !$entity->isPublished()) {
-      foreach ($parents_service->getChildren($entity) as $child) {
-        if ($child->isPublished() && $child->field_publish_with_parent->value) {
-          $child->setUnpublished();
-          $child->set('moderation_state', 'archived');
-          $child->save();
-        }
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_form_BASE_FORM_ID_alter().
- *
- * Move field_publish_with_parent next to published state.
- */
-function ecc_parents_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (isset($form['field_publish_with_parent']) && isset($form['advanced'])) {
-    $form['field_publish_with_parent']['#group'] = 'footer';
-  }
-  $nid = $form_state->getformObject()->getEntity()->id();
-  if (isset($nid) && !empty($nid)) {
-    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
-    $parents_service = \Drupal::service('ecc_parents.parents');
-    $children = $parents_service->getChildren($node);
-    if (!empty($children)) {
-      $form['#attached']['library'][] = 'ecc_parents/node.form';
-    }
-  }
-}
-
-/**
  * Implements hook_views_pre_build().
  *
  * Copy value of exposed form element to hidden parameters. This allows filter


### PR DESCRIPTION
Removes all publish-with-parent functionality.
Removes hook_node_update() and hook_form_FORM_ID_alter() hooks.
https://eccservicetransformation.atlassian.net/browse/LP-389